### PR TITLE
support for linking typescript file targets using tsx as a runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Core guarantees:
 - Links are session-scoped and cleaned on exit.
 - Collision behavior is explicit (`prompt`, `skip`, `fail`, `overwrite`).
 - Option resolution is deterministic.
+- JavaScript targets are linked directly; TypeScript targets are launched through `tsx`.
 - PATH setup for `~/.symlx/bin` is automated on install (with opt-out).
 
 ## Install
@@ -226,9 +227,15 @@ Before linking, symlx prepares each resolved bin target:
 
 - file exists
 - target is not a directory
-- target is made executable automatically on unix-like systems when possible
+- JavaScript targets are made executable automatically on unix-like systems when possible
+- TypeScript targets (`.ts`, `.tsx`, `.mts`, `.cts`) are run through `tsx`
 
-Missing targets, directories, and permission-update failures still fail early with actionable messages.
+TypeScript runtime resolution order is:
+
+1. project-local `node_modules/.bin/tsx`
+2. `tsx` on `PATH`
+
+Missing targets, directories, permission-update failures, and missing `tsx` runtime still fail early with actionable messages.
 
 ## Exit Behavior
 
@@ -255,6 +262,10 @@ symlx serve --collision overwrite
 # or
 symlx serve --collision fail
 ```
+
+## "tsx runtime could not be resolved for TypeScript target"
+
+Install `tsx` in the project or make `tsx` available on `PATH`.
 
 ## "package.json not found"
 

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -27,10 +27,10 @@ export async function linkCommand(inlineOptions: unknown): Promise<void> {
 
   cleanupStaleSessions(sessionDir);
   ensureSymlxDirectories(options.binDir, sessionDir);
-  prepareBinTargets(options.bin);
+  const preparedTargets = prepareBinTargets(cwd, options.bin);
 
   const linkResult = await createLinks(
-    options.bin,
+    preparedTargets,
     options.binDir,
     internalCollisionOption,
   );

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -39,11 +39,11 @@ export async function serveCommand(inlineOptions: unknown): Promise<void> {
   // prepare
   cleanupStaleSessions(sessionDir);
   ensureSymlxDirectories(options.binDir, sessionDir);
-  prepareBinTargets(options.bin);
+  const preparedTargets = prepareBinTargets(cwd, options.bin);
 
   // link creation
   const linkResult = await createLinks(
-    options.bin,
+    preparedTargets,
     options.binDir,
     internalCollisionOption,
   );

--- a/src/lib/bin-targets.ts
+++ b/src/lib/bin-targets.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs';
 
+import type { PreparedBinTarget } from './types';
+import { isTypeScriptTarget, resolveTsxRuntime } from './tsx-runtime';
+
 type BinTargetIssue = {
   name: string;
   target: string;
@@ -20,7 +23,10 @@ function isExecutable(filePath: string): boolean {
   }
 }
 
-function ensureExecutable(filePath: string, currentMode: number): string | undefined {
+function ensureExecutable(
+  filePath: string,
+  currentMode: number,
+): string | undefined {
   if (process.platform === 'win32' || isExecutable(filePath)) {
     return undefined;
   }
@@ -41,47 +47,6 @@ function ensureExecutable(filePath: string, currentMode: number): string | undef
   return 'target permissions could not be updated';
 }
 
-function inspectBinTarget(name: string, target: string): BinTargetIssue | undefined {
-  if (!fs.existsSync(target)) {
-    return {
-      name,
-      target,
-      reason: 'target file does not exist',
-    };
-  }
-
-  let stats: fs.Stats;
-  try {
-    stats = fs.statSync(target);
-  } catch (error) {
-    return {
-      name,
-      target,
-      reason: `target cannot be accessed (${String(error)})`,
-    };
-  }
-
-  if (stats.isDirectory()) {
-    return {
-      name,
-      target,
-      reason: 'target is a directory',
-    };
-  }
-
-  const executableIssue = ensureExecutable(target, stats.mode);
-  if (executableIssue) {
-    return {
-      name,
-      target,
-      reason: executableIssue,
-      hint: `run: chmod +x ${target}`,
-    };
-  }
-
-  return undefined;
-}
-
 function formatIssues(issues: BinTargetIssue[]): string {
   return issues
     .map((issue) => {
@@ -91,25 +56,97 @@ function formatIssues(issues: BinTargetIssue[]): string {
     .join('\n');
 }
 
-export function prepareBinTargets(bin: Record<string, string>): void {
+export function prepareBinTargets(
+  cwd: string,
+  bin: Record<string, string>,
+  currentPath: string | undefined = process.env.PATH,
+): PreparedBinTarget[] {
+  const preparedTargets: PreparedBinTarget[] = [];
   const issues: BinTargetIssue[] = [];
+  let resolvedTsxRuntime: string | null | undefined;
 
   for (const [name, target] of Object.entries(bin)) {
-    const issue = inspectBinTarget(name, target);
-    if (issue) {
-      issues.push(issue);
+    if (!fs.existsSync(target)) {
+      issues.push({
+        name,
+        target,
+        reason: 'target file does not exist',
+      });
+      continue;
     }
+
+    let stats: fs.Stats;
+    try {
+      stats = fs.statSync(target);
+    } catch (error) {
+      issues.push({
+        name,
+        target,
+        reason: `target cannot be accessed (${String(error)})`,
+      });
+      continue;
+    }
+
+    if (stats.isDirectory()) {
+      issues.push({
+        name,
+        target,
+        reason: 'target is a directory',
+      });
+      continue;
+    }
+
+    if (isTypeScriptTarget(target)) {
+      if (resolvedTsxRuntime === undefined) {
+        resolvedTsxRuntime = resolveTsxRuntime(cwd, currentPath) ?? null;
+      }
+
+      if (!resolvedTsxRuntime) {
+        issues.push({
+          name,
+          target,
+          reason: 'tsx runtime could not be resolved for TypeScript target',
+          hint: 'install tsx in the project or make tsx available on PATH',
+        });
+        continue;
+      }
+
+      preparedTargets.push({
+        name,
+        target,
+        kind: 'tsx-launcher',
+        runtimeCommand: resolvedTsxRuntime,
+      });
+      continue;
+    }
+
+    const executableIssue = ensureExecutable(target, stats.mode);
+    if (executableIssue) {
+      issues.push({
+        name,
+        target,
+        reason: executableIssue,
+        hint: `run: chmod +x ${target}`,
+      });
+      continue;
+    }
+
+    preparedTargets.push({
+      name,
+      target,
+      kind: 'symlink',
+    });
   }
 
   if (issues.length === 0) {
-    return;
+    return preparedTargets;
   }
 
   throw new Error(
     [
       'invalid bin targets:',
       formatIssues(issues),
-      'fix bin paths or file permissions in package.json, symlx.config.json, or inline --bin and run again.',
+      'fix bin paths, runtime setup, or file permissions in package.json, symlx.config.json, or inline --bin and run again.',
     ].join('\n'),
   );
 }

--- a/src/lib/link-manager.ts
+++ b/src/lib/link-manager.ts
@@ -5,8 +5,11 @@ import type {
   CollisionDecision,
   LinkConflict,
   LinkCreationResult,
+  LinkRecord,
+  PreparedBinTarget,
 } from './types';
 import { CollisionOption } from './schema';
+import { matchesTsxLauncher, writeTsxLauncher } from './tsx-runtime';
 import { promptCollisionResolver } from '../ui/prompts';
 
 type ExistingNode = {
@@ -57,6 +60,46 @@ function removeExistingNode(linkPath: string, node: ExistingNode): void {
   fs.unlinkSync(linkPath);
 }
 
+function matchesPreparedTarget(
+  linkPath: string,
+  entry: PreparedBinTarget,
+  existingNode: ExistingNode,
+): boolean {
+  if (entry.kind === 'symlink') {
+    return Boolean(
+      existingNode.existingTarget &&
+        path.resolve(existingNode.existingTarget) === path.resolve(entry.target),
+    );
+  }
+
+  if (existingNode.stats.isSymbolicLink() || !existingNode.stats.isFile()) {
+    return false;
+  }
+
+  return matchesTsxLauncher(linkPath, entry.runtimeCommand, entry.target);
+}
+
+function createCommandEntry(linkPath: string, entry: PreparedBinTarget): LinkRecord {
+  if (entry.kind === 'symlink') {
+    fs.symlinkSync(entry.target, linkPath);
+    return {
+      name: entry.name,
+      linkPath,
+      target: entry.target,
+      kind: 'symlink',
+    };
+  }
+
+  writeTsxLauncher(linkPath, entry.runtimeCommand, entry.target);
+  return {
+    name: entry.name,
+    linkPath,
+    target: entry.target,
+    kind: 'tsx-launcher',
+    runtimeCommand: entry.runtimeCommand,
+  };
+}
+
 // Normalizes filesystem state into a user-facing collision descriptor.
 function toConflict(
   name: string,
@@ -86,33 +129,26 @@ function toConflict(
   };
 }
 
-// Creates symlinks for all project bins according to the selected collision strategy.
+// Creates command entries for all prepared bins according to the selected collision strategy.
 // This function is pure with regard to policy: caller decides interactive vs non-interactive.
 export async function createLinks(
-  bins: Record<string, string>,
+  preparedTargets: PreparedBinTarget[],
   binDir: string,
   collisionOption: CollisionOption,
 ): Promise<LinkCreationResult> {
   const created = [];
   const skipped = [];
 
-  // Link every executable in the bin options
-  for (const [name, target] of Object.entries(bins)) {
-    const linkPath = path.join(binDir, name);
-    // check is there's an existing binary on the device
+  for (const entry of preparedTargets) {
+    const linkPath = path.join(binDir, entry.name);
     const existingNode = inspectExistingNode(linkPath);
 
-    // If there's a conflicting binary, handle the conflict
     if (existingNode) {
-      const conflict = toConflict(name, linkPath, target, existingNode);
+      const conflict = toConflict(entry.name, linkPath, entry.target, existingNode);
 
-      // Reusing the exact same link is always a no-op.
-      if (
-        conflict.existingTarget &&
-        path.resolve(conflict.existingTarget) === path.resolve(target)
-      ) {
+      if (matchesPreparedTarget(linkPath, entry, existingNode)) {
         skipped.push({
-          name,
+          name: entry.name,
           linkPath,
           reason: 'already linked to requested target',
         });
@@ -121,7 +157,7 @@ export async function createLinks(
 
       if (collisionOption === 'fail') {
         throw new Error(
-          `command "${name}" conflicts at ${linkPath}: ${conflict.reason}`,
+          `command "${entry.name}" conflicts at ${linkPath}: ${conflict.reason}`,
         );
       }
 
@@ -129,23 +165,21 @@ export async function createLinks(
       if (collisionOption === 'prompt') {
         collisionDecision = await promptCollisionResolver(conflict);
         if (collisionDecision === 'abort') {
-          throw new Error(`aborted on collision for command "${name}"`);
+          throw new Error(`aborted on collision for command "${entry.name}"`);
         }
       } else {
-        // After here, resulting decision can only either be 'skip' or 'overwrite'
         collisionDecision = collisionOption;
       }
 
       if (collisionDecision === 'skip') {
-        skipped.push({ name, linkPath, reason: conflict.reason });
+        skipped.push({ name: entry.name, linkPath, reason: conflict.reason });
         continue;
       }
 
       removeExistingNode(linkPath, existingNode);
     }
 
-    fs.symlinkSync(target, linkPath);
-    created.push({ name, linkPath, target });
+    created.push(createCommandEntry(linkPath, entry));
   }
 
   return { created, skipped };

--- a/src/lib/session-store.ts
+++ b/src/lib/session-store.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { LinkRecord, SessionRecord } from './types';
 import * as log from '../ui/logger';
+import { matchesTsxLauncher } from './tsx-runtime';
 import { deleteFile, loadJSONFile } from './utils';
 
 // Checks whether a PID from a previous session is still alive.
@@ -24,24 +25,43 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
-// Removes only symlinks that still point to the exact targets we created.
+function cleanupSymlink(link: Extract<LinkRecord, { kind: 'symlink' }>): void {
+  const stats = fs.lstatSync(link.linkPath);
+  if (!stats.isSymbolicLink()) {
+    return;
+  }
+
+  const linkedTo = fs.readlinkSync(link.linkPath);
+  const absoluteLinkedTo = path.resolve(path.dirname(link.linkPath), linkedTo);
+  if (absoluteLinkedTo === path.resolve(link.target)) {
+    fs.unlinkSync(link.linkPath);
+  }
+}
+
+function cleanupTsxLauncher(
+  link: Extract<LinkRecord, { kind: 'tsx-launcher' }>,
+): void {
+  const stats = fs.lstatSync(link.linkPath);
+  if (stats.isSymbolicLink() || !stats.isFile()) {
+    return;
+  }
+
+  if (matchesTsxLauncher(link.linkPath, link.runtimeCommand, link.target)) {
+    fs.unlinkSync(link.linkPath);
+  }
+}
+
+// Removes only command entries that still match the exact records we created.
 // This avoids deleting user-managed commands with the same name.
 export function cleanupLinks(links: LinkRecord[]): void {
   for (const link of links) {
     try {
-      const stats = fs.lstatSync(link.linkPath);
-      if (!stats.isSymbolicLink()) {
+      if (link.kind === 'symlink') {
+        cleanupSymlink(link);
         continue;
       }
 
-      const linkedTo = fs.readlinkSync(link.linkPath);
-      const absoluteLinkedTo = path.resolve(
-        path.dirname(link.linkPath),
-        linkedTo,
-      );
-      if (absoluteLinkedTo === path.resolve(link.target)) {
-        fs.unlinkSync(link.linkPath);
-      }
+      cleanupTsxLauncher(link);
     } catch {
       // Best-effort cleanup.
     }
@@ -57,7 +77,7 @@ export function ensureSymlxDirectories(
   fs.mkdirSync(sessionDir, { recursive: true });
 }
 
-// Reaps stale sessions left behind by crashes/kill -9 and removes their symlinks.
+// Reaps stale sessions left behind by crashes/kill -9 and removes their command entries.
 export function cleanupStaleSessions(sessionDir: string): void {
   // If the directory does not exist, return early
   if (!fs.existsSync(sessionDir)) {

--- a/src/lib/tsx-runtime.ts
+++ b/src/lib/tsx-runtime.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const TYPESCRIPT_TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
+const TSX_LAUNCHER_MARKER = '// symlx:tsx-launcher';
+
+function isExecutable(filePath: string): boolean {
+  if (!fs.existsSync(filePath)) {
+    return false;
+  }
+
+  if (process.platform === 'win32') {
+    return true;
+  }
+
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveExecutableOnPath(
+  commandName: string,
+  currentPath: string | undefined,
+): string | undefined {
+  if (!currentPath) {
+    return undefined;
+  }
+
+  for (const directory of currentPath.split(path.delimiter)) {
+    if (!directory) {
+      continue;
+    }
+
+    const candidate = path.join(directory, commandName);
+    if (isExecutable(candidate)) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+}
+
+export function isTypeScriptTarget(target: string): boolean {
+  return TYPESCRIPT_TARGET_EXTENSIONS.has(path.extname(target).toLowerCase());
+}
+
+export function resolveTsxRuntime(
+  cwd: string,
+  currentPath: string | undefined = process.env.PATH,
+): string | undefined {
+  const localCandidate = path.join(cwd, 'node_modules', '.bin', 'tsx');
+  if (isExecutable(localCandidate)) {
+    return localCandidate;
+  }
+
+  return resolveExecutableOnPath('tsx', currentPath);
+}
+
+export function createTsxLauncherContent(
+  runtimeCommand: string,
+  target: string,
+): string {
+  return `#!/usr/bin/env node
+${TSX_LAUNCHER_MARKER}
+const { spawnSync } = require('node:child_process');
+
+const runtimeCommand = ${JSON.stringify(runtimeCommand)};
+const targetPath = ${JSON.stringify(target)};
+
+const result = spawnSync(
+  runtimeCommand,
+  [targetPath, ...process.argv.slice(2)],
+  { stdio: 'inherit' },
+);
+
+if (result.error) {
+  process.stderr.write(
+    '[symlx] failed to launch TypeScript target via tsx: ' +
+      String(result.error) +
+      '\\n',
+  );
+  process.exit(1);
+}
+
+if (typeof result.status === 'number') {
+  process.exit(result.status);
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(1);
+`;
+}
+
+export function writeTsxLauncher(
+  linkPath: string,
+  runtimeCommand: string,
+  target: string,
+): void {
+  fs.writeFileSync(
+    linkPath,
+    createTsxLauncherContent(runtimeCommand, target),
+    'utf8',
+  );
+  fs.chmodSync(linkPath, 0o755);
+}
+
+export function matchesTsxLauncher(
+  linkPath: string,
+  runtimeCommand: string,
+  target: string,
+): boolean {
+  try {
+    const content = fs.readFileSync(linkPath, 'utf8');
+    return content === createTsxLauncherContent(runtimeCommand, target);
+  } catch {
+    return false;
+  }
+}
+
+export { TSX_LAUNCHER_MARKER };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,12 +4,34 @@ export type PackageJson = {
   bin?: string | Record<string, string>;
 };
 
-// A symlink created by symlx for a single command name.
-export type LinkRecord = {
-  name: string;
-  linkPath: string;
-  target: string;
-};
+export type PreparedBinTarget =
+  | {
+      name: string;
+      target: string;
+      kind: 'symlink';
+    }
+  | {
+      name: string;
+      target: string;
+      kind: 'tsx-launcher';
+      runtimeCommand: string;
+    };
+
+// A command entry created by symlx for a single command name.
+export type LinkRecord =
+  | {
+      name: string;
+      linkPath: string;
+      target: string;
+      kind: 'symlink';
+    }
+  | {
+      name: string;
+      linkPath: string;
+      target: string;
+      kind: 'tsx-launcher';
+      runtimeCommand: string;
+    };
 
 // Session metadata persisted to disk so stale links can be recovered/cleaned later.
 export type SessionRecord = {

--- a/test/bin-targets.test.ts
+++ b/test/bin-targets.test.ts
@@ -15,11 +15,25 @@ function withTempDir(run: (dirPath: string) => void): void {
   }
 }
 
+function writeTarget(filePath: string, mode = 0o644): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '#!/usr/bin/env node\nconsole.log("ok")\n');
+  fs.chmodSync(filePath, mode);
+}
+
+function writeTsxBinary(projectDirectory: string): string {
+  const tsxPath = path.join(projectDirectory, 'node_modules', '.bin', 'tsx');
+  fs.mkdirSync(path.dirname(tsxPath), { recursive: true });
+  fs.writeFileSync(tsxPath, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(tsxPath, 0o755);
+  return tsxPath;
+}
+
 test('rejects missing target files', () => {
   withTempDir((dirPath) => {
     const missingTarget = path.join(dirPath, 'dist', 'cli.js');
     assert.throws(
-      () => prepareBinTargets({ 'my-cli': missingTarget }),
+      () => prepareBinTargets(dirPath, { 'my-cli': missingTarget }, ''),
       /target file does not exist/,
     );
   });
@@ -31,38 +45,67 @@ test('rejects directory targets', () => {
     fs.mkdirSync(targetDirectory, { recursive: true });
 
     assert.throws(
-      () => prepareBinTargets({ 'my-cli': targetDirectory }),
+      () => prepareBinTargets(dirPath, { 'my-cli': targetDirectory }, ''),
       /target is a directory/,
     );
   });
 });
 
-test('accepts executable files', () => {
+test('prepares executable JavaScript targets as symlinks', () => {
   withTempDir((dirPath) => {
-    const filePath = path.join(dirPath, 'cli.sh');
-    fs.writeFileSync(filePath, '#!/usr/bin/env sh\necho ok\n');
-    fs.chmodSync(filePath, 0o755);
+    const filePath = path.join(dirPath, 'cli.js');
+    writeTarget(filePath, 0o755);
 
-    assert.doesNotThrow(() => {
-      prepareBinTargets({ 'my-cli': filePath });
-    });
+    const result = prepareBinTargets(dirPath, { 'my-cli': filePath }, '');
+    assert.deepEqual(result, [
+      { name: 'my-cli', target: filePath, kind: 'symlink' },
+    ]);
   });
 });
 
-test('makes non-executable files executable on unix-like systems', () => {
+test('makes non-executable JavaScript targets executable on unix-like systems', () => {
   if (process.platform === 'win32') {
     return;
   }
 
   withTempDir((dirPath) => {
-    const filePath = path.join(dirPath, 'cli.sh');
-    fs.writeFileSync(filePath, '#!/usr/bin/env sh\necho ok\n');
-    fs.chmodSync(filePath, 0o644);
+    const filePath = path.join(dirPath, 'cli.js');
+    writeTarget(filePath, 0o644);
 
-    assert.doesNotThrow(() => {
-      prepareBinTargets({ 'my-cli': filePath });
-    });
-
+    const result = prepareBinTargets(dirPath, { 'my-cli': filePath }, '');
+    assert.deepEqual(result, [
+      { name: 'my-cli', target: filePath, kind: 'symlink' },
+    ]);
     fs.accessSync(filePath, fs.constants.X_OK);
+  });
+});
+
+test('prepares TypeScript targets as tsx launchers', () => {
+  withTempDir((dirPath) => {
+    const targetPath = path.join(dirPath, 'src', 'cli.ts');
+    writeTarget(targetPath, 0o644);
+    const runtimeCommand = writeTsxBinary(dirPath);
+
+    const result = prepareBinTargets(dirPath, { 'my-cli': targetPath }, '');
+    assert.deepEqual(result, [
+      {
+        name: 'my-cli',
+        target: targetPath,
+        kind: 'tsx-launcher',
+        runtimeCommand,
+      },
+    ]);
+  });
+});
+
+test('rejects TypeScript targets when tsx cannot be resolved', () => {
+  withTempDir((dirPath) => {
+    const targetPath = path.join(dirPath, 'src', 'cli.ts');
+    writeTarget(targetPath, 0o644);
+
+    assert.throws(
+      () => prepareBinTargets(dirPath, { 'my-cli': targetPath }, ''),
+      /tsx runtime could not be resolved/,
+    );
   });
 });

--- a/test/link-command.test.ts
+++ b/test/link-command.test.ts
@@ -14,10 +14,21 @@ function withTempDir(run: (dirPath: string) => void): void {
   }
 }
 
-function writeCliTarget(filePath: string, mode: number): void {
+function writeTarget(filePath: string, mode: number): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, '#!/usr/bin/env node\nconsole.log("ok")\n');
   fs.chmodSync(filePath, mode);
+}
+
+function writeTsxStub(projectDirectory: string): string {
+  const tsxPath = path.join(projectDirectory, 'node_modules', '.bin', 'tsx');
+  fs.mkdirSync(path.dirname(tsxPath), { recursive: true });
+  fs.writeFileSync(
+    tsxPath,
+    '#!/bin/sh\nprintf "%s\\n" "$@" > "$SYMLX_TSX_ARGS_FILE"\nexit 0\n',
+  );
+  fs.chmodSync(tsxPath, 0o755);
+  return tsxPath;
 }
 
 function writeJSON(filePath: string, value: unknown): void {
@@ -27,13 +38,16 @@ function writeJSON(filePath: string, value: unknown): void {
 function runCli(
   args: string[],
   cwd: string,
-  homeDirectory?: string,
+  options: {
+    homeDirectory?: string;
+    extraEnv?: NodeJS.ProcessEnv;
+  } = {},
 ): ReturnType<typeof spawnSync> {
   const cliPath = path.join(process.cwd(), '.tmp-tests', 'src', 'cli.js');
-  const env = { ...process.env };
-  if (homeDirectory) {
-    env.HOME = homeDirectory;
-    env.USERPROFILE = homeDirectory;
+  const env = { ...process.env, ...(options.extraEnv ?? {}) };
+  if (options.homeDirectory) {
+    env.HOME = options.homeDirectory;
+    env.USERPROFILE = options.homeDirectory;
   }
 
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -55,7 +69,7 @@ test('cli help shows the link command', () => {
 const isWindows = process.platform === 'win32';
 
 test(
-  'link creates project command links and exits without writing a session record',
+  'link creates project JavaScript command entries and exits without writing a session record',
   { skip: isWindows },
   () => {
     withTempDir((dirPath) => {
@@ -71,12 +85,12 @@ test(
         },
       });
 
-      writeCliTarget(path.join(projectDirectory, 'dist', 'cli.js'), 0o755);
+      writeTarget(path.join(projectDirectory, 'dist', 'cli.js'), 0o755);
 
       const result = runCli(
         ['link', '--collision', 'overwrite'],
         projectDirectory,
-        homeDirectory,
+        { homeDirectory },
       );
 
       assert.equal(
@@ -98,7 +112,7 @@ test(
 );
 
 test(
-  'link makes non-executable bin targets executable before linking',
+  'link makes non-executable JavaScript targets executable before linking',
   { skip: isWindows },
   () => {
     withTempDir((dirPath) => {
@@ -115,12 +129,12 @@ test(
         },
       });
 
-      writeCliTarget(targetPath, 0o644);
+      writeTarget(targetPath, 0o644);
 
       const result = runCli(
         ['link', '--collision', 'overwrite'],
         projectDirectory,
-        homeDirectory,
+        { homeDirectory },
       );
 
       assert.equal(
@@ -132,6 +146,73 @@ test(
       fs.accessSync(targetPath, fs.constants.X_OK);
       const linkPath = path.join(homeDirectory, '.symlx', 'bin', 'sample-cli');
       assert.equal(fs.lstatSync(linkPath).isSymbolicLink(), true);
+    });
+  },
+);
+
+test(
+  'link creates tsx launchers for TypeScript targets and executes them through local tsx',
+  { skip: isWindows },
+  () => {
+    withTempDir((dirPath) => {
+      const homeDirectory = path.join(dirPath, 'home');
+      const projectDirectory = path.join(dirPath, 'project');
+      const argsFile = path.join(dirPath, 'tsx-args.txt');
+      const targetPath = path.join(projectDirectory, 'src', 'cli.ts');
+      fs.mkdirSync(homeDirectory, { recursive: true });
+      fs.mkdirSync(projectDirectory, { recursive: true });
+      const expectedTargetPath = fs.realpathSync.native(projectDirectory);
+
+      writeJSON(path.join(projectDirectory, 'package.json'), {
+        name: 'sample-cli-project',
+        bin: {
+          'sample-cli': './src/cli.ts',
+        },
+      });
+
+      writeTarget(targetPath, 0o644);
+      writeTsxStub(projectDirectory);
+
+      const result = runCli(
+        ['link', '--collision', 'overwrite'],
+        projectDirectory,
+        {
+          homeDirectory,
+          extraEnv: { SYMLX_TSX_ARGS_FILE: argsFile },
+        },
+      );
+
+      assert.equal(
+        result.status,
+        0,
+        `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+
+      const linkPath = path.join(homeDirectory, '.symlx', 'bin', 'sample-cli');
+      const stats = fs.lstatSync(linkPath);
+      assert.equal(stats.isSymbolicLink(), false);
+      assert.equal(stats.isFile(), true);
+      fs.accessSync(linkPath, fs.constants.X_OK);
+
+      const runResult = spawnSync(linkPath, ['--flag', 'value'], {
+        env: {
+          ...process.env,
+          SYMLX_TSX_ARGS_FILE: argsFile,
+        },
+        encoding: 'utf8',
+      });
+
+      assert.equal(
+        runResult.status,
+        0,
+        `stdout:\n${runResult.stdout}\nstderr:\n${runResult.stderr}`,
+      );
+
+      const capturedArgs = fs
+        .readFileSync(argsFile, 'utf8')
+        .trim()
+        .split('\n');
+      assert.deepEqual(capturedArgs, [path.join(expectedTargetPath, 'src', 'cli.ts'), '--flag', 'value']);
     });
   },
 );

--- a/test/link-manager.test.ts
+++ b/test/link-manager.test.ts
@@ -5,6 +5,12 @@ import path from 'node:path';
 import { test } from 'node:test';
 
 import { createLinks } from '../src/lib/link-manager';
+import {
+  matchesTsxLauncher,
+  writeTsxLauncher,
+} from '../src/lib/tsx-runtime';
+
+import type { PreparedBinTarget } from '../src/lib/types';
 
 function withTempDir(run: (dirPath: string) => Promise<void> | void): Promise<void> {
   const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'symlx-link-test-'));
@@ -23,21 +29,56 @@ function createTargetFile(dirPath: string, basename: string): string {
 
 const isWindows = process.platform === 'win32';
 
-test('createLinks creates new symlinks for non-conflicting bins', { skip: isWindows }, async () => {
+test('createLinks creates symlinks for prepared JavaScript targets', { skip: isWindows }, async () => {
   await withTempDir(async (dirPath) => {
     const binDir = path.join(dirPath, 'bin');
     fs.mkdirSync(binDir, { recursive: true });
 
     const target = createTargetFile(dirPath, 'cli.js');
+    const preparedTargets: PreparedBinTarget[] = [
+      { name: 'my-cli', target, kind: 'symlink' },
+    ];
 
-    const result = await createLinks({ 'my-cli': target }, binDir, 'fail');
+    const result = await createLinks(preparedTargets, binDir, 'fail');
 
     assert.equal(result.created.length, 1);
     assert.equal(result.skipped.length, 0);
 
     const linkPath = path.join(binDir, 'my-cli');
     assert.equal(fs.lstatSync(linkPath).isSymbolicLink(), true);
-    assert.equal(path.resolve(path.dirname(linkPath), fs.readlinkSync(linkPath)), target);
+    assert.equal(
+      path.resolve(path.dirname(linkPath), fs.readlinkSync(linkPath)),
+      target,
+    );
+  });
+});
+
+test('createLinks creates tsx launchers for prepared TypeScript targets', { skip: isWindows }, async () => {
+  await withTempDir(async (dirPath) => {
+    const binDir = path.join(dirPath, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+
+    const target = path.join(dirPath, 'cli.ts');
+    fs.writeFileSync(target, 'console.log("ok")\n');
+    const runtimeCommand = path.join(dirPath, 'tsx');
+
+    const preparedTargets: PreparedBinTarget[] = [
+      {
+        name: 'my-cli',
+        target,
+        kind: 'tsx-launcher',
+        runtimeCommand,
+      },
+    ];
+
+    const result = await createLinks(preparedTargets, binDir, 'fail');
+
+    assert.equal(result.created.length, 1);
+    const linkPath = path.join(binDir, 'my-cli');
+    assert.equal(fs.lstatSync(linkPath).isFile(), true);
+    assert.equal(fs.lstatSync(linkPath).isSymbolicLink(), false);
+    assert.equal(matchesTsxLauncher(linkPath, runtimeCommand, target), true);
+    fs.accessSync(linkPath, fs.constants.X_OK);
   });
 });
 
@@ -50,7 +91,11 @@ test('createLinks skip policy skips existing file conflicts', { skip: isWindows 
     const existingPath = path.join(binDir, 'my-cli');
     fs.writeFileSync(existingPath, 'existing');
 
-    const result = await createLinks({ 'my-cli': target }, binDir, 'skip');
+    const result = await createLinks(
+      [{ name: 'my-cli', target, kind: 'symlink' }],
+      binDir,
+      'skip',
+    );
 
     assert.equal(result.created.length, 0);
     assert.equal(result.skipped.length, 1);
@@ -68,7 +113,7 @@ test('createLinks overwrite policy replaces existing file with symlink', { skip:
     fs.writeFileSync(existingPath, 'existing');
 
     const result = await createLinks(
-      { 'my-cli': target },
+      [{ name: 'my-cli', target, kind: 'symlink' }],
       binDir,
       'overwrite',
     );
@@ -87,7 +132,7 @@ test('createLinks fail policy throws on conflict', { skip: isWindows }, async ()
     fs.writeFileSync(path.join(binDir, 'my-cli'), 'existing');
 
     await assert.rejects(
-      () => createLinks({ 'my-cli': target }, binDir, 'fail'),
+      () => createLinks([{ name: 'my-cli', target, kind: 'symlink' }], binDir, 'fail'),
       /conflicts/,
     );
   });
@@ -103,7 +148,37 @@ test('createLinks skips when existing symlink already points to target', { skip:
     fs.symlinkSync(target, linkPath);
 
     const result = await createLinks(
-      { 'my-cli': target },
+      [{ name: 'my-cli', target, kind: 'symlink' }],
+      binDir,
+      'overwrite',
+    );
+
+    assert.equal(result.created.length, 0);
+    assert.equal(result.skipped.length, 1);
+    assert.match(result.skipped[0].reason, /already linked/);
+  });
+});
+
+test('createLinks skips when existing tsx launcher already matches target', { skip: isWindows }, async () => {
+  await withTempDir(async (dirPath) => {
+    const binDir = path.join(dirPath, 'bin');
+    fs.mkdirSync(binDir, { recursive: true });
+
+    const target = path.join(dirPath, 'cli.ts');
+    fs.writeFileSync(target, 'console.log("ok")\n');
+    const runtimeCommand = path.join(dirPath, 'tsx');
+    const linkPath = path.join(binDir, 'my-cli');
+    writeTsxLauncher(linkPath, runtimeCommand, target);
+
+    const result = await createLinks(
+      [
+        {
+          name: 'my-cli',
+          target,
+          kind: 'tsx-launcher',
+          runtimeCommand,
+        },
+      ],
       binDir,
       'overwrite',
     );
@@ -123,7 +198,7 @@ test('createLinks refuses to overwrite directory collisions', { skip: isWindows 
     fs.mkdirSync(path.join(binDir, 'my-cli'));
 
     await assert.rejects(
-      () => createLinks({ 'my-cli': target }, binDir, 'overwrite'),
+      () => createLinks([{ name: 'my-cli', target, kind: 'symlink' }], binDir, 'overwrite'),
       /cannot overwrite directory/,
     );
   });

--- a/test/serve-command.test.ts
+++ b/test/serve-command.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { spawn, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { test } from 'node:test';
+
+function withTempDir(run: (dirPath: string) => Promise<void> | void): Promise<void> {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'symlx-serve-command-'));
+  return Promise.resolve(run(dirPath)).finally(() => {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  });
+}
+
+function writeTarget(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, 'console.log("ok")\n');
+  fs.chmodSync(filePath, 0o644);
+}
+
+function writeTsxStub(projectDirectory: string): string {
+  const tsxPath = path.join(projectDirectory, 'node_modules', '.bin', 'tsx');
+  fs.mkdirSync(path.dirname(tsxPath), { recursive: true });
+  fs.writeFileSync(
+    tsxPath,
+    '#!/bin/sh\nprintf "%s\\n" "$@" > "$SYMLX_TSX_ARGS_FILE"\nexit 0\n',
+  );
+  fs.chmodSync(tsxPath, 0o755);
+  return tsxPath;
+}
+
+function writeJSON(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) {
+      return;
+    }
+    await delay(50);
+  }
+
+  throw new Error('timed out waiting for condition');
+}
+
+const isWindows = process.platform === 'win32';
+
+test(
+  'serve keeps TypeScript command launchers active and cleans them up on exit',
+  { skip: isWindows },
+  async () => {
+    await withTempDir(async (dirPath) => {
+      const homeDirectory = path.join(dirPath, 'home');
+      const projectDirectory = path.join(dirPath, 'project');
+      const argsFile = path.join(dirPath, 'tsx-args.txt');
+      const targetPath = path.join(projectDirectory, 'src', 'cli.ts');
+      fs.mkdirSync(homeDirectory, { recursive: true });
+      fs.mkdirSync(projectDirectory, { recursive: true });
+      const expectedTargetPath = fs.realpathSync.native(projectDirectory);
+
+      writeJSON(path.join(projectDirectory, 'package.json'), {
+        name: 'sample-cli-project',
+        bin: {
+          'sample-cli': './src/cli.ts',
+        },
+      });
+
+      writeTarget(targetPath);
+      writeTsxStub(projectDirectory);
+
+      const cliPath = path.join(process.cwd(), '.tmp-tests', 'src', 'cli.js');
+      const child = spawn(process.execPath, [cliPath, 'serve', '--collision', 'overwrite'], {
+        cwd: projectDirectory,
+        env: {
+          ...process.env,
+          HOME: homeDirectory,
+          USERPROFILE: homeDirectory,
+          SYMLX_TSX_ARGS_FILE: argsFile,
+        },
+        stdio: 'pipe',
+      });
+
+      const linkPath = path.join(homeDirectory, '.symlx', 'bin', 'sample-cli');
+      await waitFor(() => fs.existsSync(linkPath));
+
+      const stats = fs.lstatSync(linkPath);
+      assert.equal(stats.isSymbolicLink(), false);
+      assert.equal(stats.isFile(), true);
+
+      const runResult = spawnSync(linkPath, ['--help'], {
+        env: {
+          ...process.env,
+          SYMLX_TSX_ARGS_FILE: argsFile,
+        },
+        encoding: 'utf8',
+      });
+      assert.equal(
+        runResult.status,
+        0,
+        `stdout:\n${runResult.stdout}\nstderr:\n${runResult.stderr}`,
+      );
+
+      const capturedArgs = fs
+        .readFileSync(argsFile, 'utf8')
+        .trim()
+        .split('\n');
+      assert.deepEqual(capturedArgs, [path.join(expectedTargetPath, 'src', 'cli.ts'), '--help']);
+
+      child.kill('SIGTERM');
+      await once(child, 'exit');
+      await waitFor(() => !fs.existsSync(linkPath));
+    });
+  },
+);

--- a/test/session-store.test.ts
+++ b/test/session-store.test.ts
@@ -12,6 +12,7 @@ import {
   ensureSymlxDirectories,
   persistSession,
 } from '../src/lib/session-store';
+import { writeTsxLauncher } from '../src/lib/tsx-runtime';
 
 import type { LinkRecord } from '../src/lib/types';
 
@@ -53,7 +54,9 @@ test('cleanupLinks removes tracked symlink when target matches', { skip: isWindo
     fs.mkdirSync(path.dirname(linkPath), { recursive: true });
     fs.symlinkSync(target, linkPath);
 
-    const links: LinkRecord[] = [{ name: 'my-cli', linkPath, target }];
+    const links: LinkRecord[] = [
+      { name: 'my-cli', linkPath, target, kind: 'symlink' },
+    ];
     cleanupLinks(links);
 
     assert.equal(fs.existsSync(linkPath), false);
@@ -72,7 +75,62 @@ test('cleanupLinks does not remove symlink when target mismatch', { skip: isWind
     fs.symlinkSync(actualTarget, linkPath);
 
     const links: LinkRecord[] = [
-      { name: 'my-cli', linkPath, target: expectedTarget },
+      { name: 'my-cli', linkPath, target: expectedTarget, kind: 'symlink' },
+    ];
+    cleanupLinks(links);
+
+    assert.equal(fs.existsSync(linkPath), true);
+  });
+});
+
+test('cleanupLinks removes tracked tsx launcher when content matches', { skip: isWindows }, () => {
+  withTempDir((dirPath) => {
+    const target = path.join(dirPath, 'src', 'cli.ts');
+    const runtimeCommand = path.join(dirPath, 'node_modules', '.bin', 'tsx');
+    createExecutable(runtimeCommand);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, 'console.log("ok")\n');
+
+    const linkPath = path.join(dirPath, 'bin', 'my-cli');
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    writeTsxLauncher(linkPath, runtimeCommand, target);
+
+    const links: LinkRecord[] = [
+      {
+        name: 'my-cli',
+        linkPath,
+        target,
+        kind: 'tsx-launcher',
+        runtimeCommand,
+      },
+    ];
+    cleanupLinks(links);
+
+    assert.equal(fs.existsSync(linkPath), false);
+  });
+});
+
+test('cleanupLinks does not remove modified tsx launcher files', { skip: isWindows }, () => {
+  withTempDir((dirPath) => {
+    const target = path.join(dirPath, 'src', 'cli.ts');
+    const runtimeCommand = path.join(dirPath, 'node_modules', '.bin', 'tsx');
+    createExecutable(runtimeCommand);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, 'console.log("ok")\n');
+
+    const linkPath = path.join(dirPath, 'bin', 'my-cli');
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.writeFileSync(linkPath, '#!/usr/bin/env node\nconsole.log("changed")\n');
+    fs.chmodSync(linkPath, 0o755);
+
+    const links: LinkRecord[] = [
+      {
+        name: 'my-cli',
+        linkPath,
+        target,
+        kind: 'tsx-launcher',
+        runtimeCommand,
+      },
     ];
     cleanupLinks(links);
 
@@ -98,7 +156,7 @@ test('cleanupStaleSessions removes stale sessions and non-json files', { skip: i
       pid: -1,
       cwd: dirPath,
       createdAt: new Date().toISOString(),
-      links: [{ name: 'my-cli', linkPath, target }],
+      links: [{ name: 'my-cli', linkPath, target, kind: 'symlink' }],
     });
 
     cleanupStaleSessions(sessionDir);
@@ -126,7 +184,7 @@ test('cleanupStaleSessions keeps active sessions for live pids', { skip: isWindo
       pid: process.pid,
       cwd: dirPath,
       createdAt: new Date().toISOString(),
-      links: [{ name: 'my-cli', linkPath, target }],
+      links: [{ name: 'my-cli', linkPath, target, kind: 'symlink' }],
     });
 
     cleanupStaleSessions(sessionDir);
@@ -148,7 +206,7 @@ test('generateSessionFilePath creates json path inside session dir', () => {
 
 test('generateSessionRecord uses current pid and provided values', () => {
   const links: LinkRecord[] = [
-    { name: 'tool', linkPath: '/tmp/tool', target: '/tmp/cli.js' },
+    { name: 'tool', linkPath: '/tmp/tool', target: '/tmp/cli.js', kind: 'symlink' },
   ];
   const cwd = '/tmp/project';
   const record = generateSessionRecord(cwd, links);

--- a/test/tsx-runtime.test.ts
+++ b/test/tsx-runtime.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  isTypeScriptTarget,
+  resolveTsxRuntime,
+} from '../src/lib/tsx-runtime';
+
+function withTempDir(run: (dirPath: string) => void): void {
+  const dirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'symlx-tsx-runtime-'));
+  try {
+    run(dirPath);
+  } finally {
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+}
+
+function writeExecutable(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(filePath, 0o755);
+}
+
+test('isTypeScriptTarget detects supported TypeScript extensions', () => {
+  assert.equal(isTypeScriptTarget('/tmp/cli.ts'), true);
+  assert.equal(isTypeScriptTarget('/tmp/cli.tsx'), true);
+  assert.equal(isTypeScriptTarget('/tmp/cli.mts'), true);
+  assert.equal(isTypeScriptTarget('/tmp/cli.cts'), true);
+  assert.equal(isTypeScriptTarget('/tmp/cli.js'), false);
+});
+
+test('resolveTsxRuntime prefers project-local tsx over PATH', () => {
+  withTempDir((dirPath) => {
+    const localTsx = path.join(dirPath, 'node_modules', '.bin', 'tsx');
+    const pathTsx = path.join(dirPath, 'path-bin', 'tsx');
+    writeExecutable(localTsx);
+    writeExecutable(pathTsx);
+
+    const result = resolveTsxRuntime(dirPath, path.dirname(pathTsx));
+    assert.equal(result, localTsx);
+  });
+});
+
+test('resolveTsxRuntime falls back to PATH when local tsx is absent', () => {
+  withTempDir((dirPath) => {
+    const pathTsx = path.join(dirPath, 'path-bin', 'tsx');
+    writeExecutable(pathTsx);
+
+    const result = resolveTsxRuntime(dirPath, path.dirname(pathTsx));
+    assert.equal(result, pathTsx);
+  });
+});
+
+test('resolveTsxRuntime returns undefined when tsx cannot be resolved', () => {
+  withTempDir((dirPath) => {
+    const result = resolveTsxRuntime(dirPath, '');
+    assert.equal(result, undefined);
+  });
+});

--- a/usage/link.md
+++ b/usage/link.md
@@ -1,7 +1,9 @@
 # `link` Usage Scenarios
 
-`link` resolves bins, creates command symlinks, prints results, and exits immediately.
+`link` resolves bins, creates command entries, prints results, and exits immediately.
 Unlike `serve`, it does not keep a live session and does not auto-clean on process exit.
+
+JavaScript targets are linked directly. TypeScript targets are launched through generated `tsx` wrappers.
 
 ## Command
 
@@ -29,8 +31,9 @@ symlx link
 
 Expected outcome:
 
-- commands are linked into your bin dir
-- command mapping is printed
+- commands are created in your bin dir
+- JavaScript targets become symlinks
+- TypeScript targets become executable `tsx` launchers
 - process exits with status `0`
 
 ## Override One Command Inline
@@ -113,7 +116,7 @@ Expected failure:
 
 ### Invalid Bin Target
 
-If a resolved bin target is missing, cannot be made executable, or is a directory:
+If a resolved bin target is missing, cannot be made executable, is a directory, or is TypeScript without `tsx` available:
 
 - process exits `1`
 - error tells the exact command and target issue
@@ -122,4 +125,5 @@ Recovery:
 
 1. build the target (`dist/...`)
 2. ensure the target file exists
-3. if permission repair fails, set executable permission manually (`chmod +x`)
+3. if the target is TypeScript, install `tsx` locally or make it available on `PATH`
+4. if permission repair still fails for JavaScript, set executable permission manually (`chmod +x`)

--- a/usage/serve.md
+++ b/usage/serve.md
@@ -14,7 +14,7 @@ cx serve [options]
 
 1. Resolve options from defaults, package.json, config, and inline flags.
 2. Resolve final `bin` map with `replace` or `merge` strategy.
-3. Prepare all resolved bin targets and make them executable when needed.
+3. Prepare all resolved bin targets, make them executable when needed, and convert TypeScript targets into `tsx` launchers.
 4. Cleanup stale sessions.
 5. Create links with collision policy.
 6. Persist session metadata.
@@ -107,7 +107,32 @@ Outcome:
 - bins are merged from package + config + inline
 - in this case, both `cfg-tool --help` and `inline-tool --help` works
 
-## 5) Custom bin directory
+## 5) TypeScript bin target
+
+`package.json`:
+
+```json
+{
+  "name": "my-cli",
+  "bin": {
+    "my-cli": "./src/cli.ts"
+  }
+}
+```
+
+Run:
+
+```bash
+symlx serve
+```
+
+Outcome:
+
+- symlx creates a command launcher in the bin dir
+- the launcher runs the real target through `tsx`
+- `tsx` is resolved from local `node_modules/.bin/tsx` first, then `PATH`
+
+## 6) Custom bin directory
 
 Run:
 
@@ -121,7 +146,7 @@ Outcome:
 
 ## Collision Scenarios
 
-## 6) Prompt mode
+## 7) Prompt mode
 
 Run:
 
@@ -133,7 +158,7 @@ Outcome:
 
 - interactive choice per conflict: overwrite / skip / abort
 
-## 7) Skip mode
+## 8) Skip mode
 
 Run:
 
@@ -146,7 +171,7 @@ Outcome:
 - conflicting names are skipped
 - non-conflicting names still link
 
-## 8) Fail mode
+## 9) Fail mode
 
 Run:
 
@@ -158,7 +183,7 @@ Outcome:
 
 - first collision throws and stops linking
 
-## 9) Overwrite mode
+## 10) Overwrite mode
 
 Run:
 
@@ -170,7 +195,7 @@ Outcome:
 
 - conflicting entries are replaced
 
-## 10) Prompt requested in non-interactive mode
+## 11) Prompt requested in non-interactive mode
 
 Run:
 
@@ -185,7 +210,7 @@ Outcome:
 
 ## Resolution Scenarios
 
-## 11) Replace strategy (default)
+## 12) Replace strategy (default)
 
 Run:
 
@@ -201,7 +226,7 @@ Outcome:
   - package
 - i.e. if bin is specified inline, bin from the config or package.json is ignored
 
-## 12) Merge strategy from CLI
+## 13) Merge strategy from CLI
 
 Run:
 
@@ -215,7 +240,7 @@ Outcome:
 
 ## Validation and Edge Cases
 
-## 13) Missing `package.json`
+## 14) Missing `package.json`
 
 Run in directory without `package.json` and without any config/inline bins.
 
@@ -223,19 +248,19 @@ Outcome:
 
 - explicit error: "package.json not found"
 
-## 14) Invalid `package.json` JSON
+## 15) Invalid `package.json` JSON
 
 Outcome:
 
 - explicit parse error with file path
 
-## 15) No bin entries anywhere
+## 16) No bin entries anywhere
 
 Outcome:
 
 - error with exact locations where bin can be defined
 
-## 16) Bin string without package name
+## 17) Bin string without package name
 
 `package.json`:
 
@@ -249,7 +274,7 @@ Outcome:
 
 - error: cannot infer command name, set valid package name
 
-## 17) Invalid inline bin name
+## 18) Invalid inline bin name
 
 Run:
 
@@ -261,7 +286,7 @@ Outcome:
 
 - schema error (name format invalid)
 
-## 18) Invalid inline bin path (absolute)
+## 19) Invalid inline bin path (absolute)
 
 Run:
 
@@ -273,7 +298,7 @@ Outcome:
 
 - schema error (absolute target not allowed)
 
-## 19) Missing target file
+## 20) Missing target file
 
 Any resolved bin pointing to missing file.
 
@@ -281,19 +306,25 @@ Outcome:
 
 - early runtime validation error before link creation
 
-## 20) Target is a directory
+## 21) Target is a directory
 
 Outcome:
 
 - early runtime validation error
 
-## 21) Target is not executable (unix-like)
+## 22) Target is not executable (unix-like)
 
 Outcome:
 
-- symlx makes the target executable before linking
+- for JavaScript targets, symlx makes the target executable before linking
 
-## 22) Invalid config for non-critical keys
+## 23) TypeScript target without tsx
+
+Outcome:
+
+- early runtime validation error telling you to install `tsx` locally or make it available on `PATH`
+
+## 24) Invalid config for non-critical keys
 
 `symlx.config.json`:
 
@@ -309,7 +340,7 @@ Outcome:
 - warning logs
 - defaults applied
 
-## 23) Invalid config for critical key (`binDir`)
+## 25) Invalid config for critical key (`binDir`)
 
 Outcome:
 
@@ -317,7 +348,7 @@ Outcome:
 
 ## Lifecycle Scenarios
 
-## 24) Controlled exit
+## 26) Controlled exit
 
 Stop with `Ctrl+C`.
 
@@ -326,7 +357,7 @@ Outcome:
 - active session links removed
 - session metadata file removed
 
-## 25) Stale crash recovery
+## 27) Stale crash recovery
 
 Previous run crashed and left stale session metadata.
 
@@ -351,11 +382,11 @@ Outcome:
 
 - confirm file exists
 - confirm path is relative in config/inline
-- if symlx still fails, fix the file permission manually (`chmod +x`)
+- if the target is TypeScript, install `tsx` locally or make it available on `PATH`
+- if symlx still fails for JavaScript, fix the file permission manually (`chmod +x`)
 
 ## "no links were created because all candidate commands were skipped"
 
 - switch collision policy to:
   - `--collision overwrite`
   - `--collision fail`
-


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TypeScript binary targets, automatically executed through tsx runtime
  * Implemented tsx runtime resolution from project-local and PATH locations

* **Improvements**
  * Enhanced runtime safety checks with clearer error messages for missing tsx
  * Updated documentation for binary target handling in link and serve workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->