### PR TITLE
fix issue with unknown file extension when using a node shebang for a typescript target

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Current launcher inference:
 
 - `.js`, `.mjs`, `.cjs` -> Node launcher
 - `.ts`, `.tsx`, `.mts`, `.cts` -> `tsx` launcher
+- if a TypeScript target declares `#!/usr/bin/env node`, symlx fails early and tells you to use `tsx` shebang or remove shebang for launcher inference
 
 TypeScript runtime resolution order is:
 
@@ -286,6 +287,11 @@ symlx serve --collision fail
 ## "tsx runtime could not be resolved for target"
 
 Install `tsx` in the project or make `tsx` available on `PATH`.
+
+## "typescript target uses node shebang and is not directly runnable"
+
+- replace shebang with `#!/usr/bin/env tsx`
+- or remove shebang and let symlx infer launcher by file type
 
 ## "package.json not found"
 

--- a/src/lib/bin-targets.ts
+++ b/src/lib/bin-targets.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 import { resolveInferredLauncher } from './launchers';
-import { hasShebang } from './shebang';
+import { readShebang, extractShebangRuntime } from './shebang';
 import type { PreparedBinTarget } from './types';
 
 type BinTargetIssue = {
@@ -14,6 +15,8 @@ type BinTargetIssue = {
 type PrepareBinTargetsOptions = {
   currentPath?: string | undefined;
 };
+
+const TYPESCRIPT_TARGET_EXTENSIONS = new Set(['.ts', '.tsx', '.mts', '.cts']);
 
 function isExecutable(filePath: string): boolean {
   if (process.platform === 'win32') {
@@ -77,6 +80,27 @@ function addUnsupportedWithoutShebangIssue(
   });
 }
 
+function isTypeScriptTarget(targetPath: string): boolean {
+  return TYPESCRIPT_TARGET_EXTENSIONS.has(
+    path.extname(targetPath).toLowerCase(),
+  );
+}
+
+function addInvalidTypeScriptNodeShebangIssue(
+  issues: BinTargetIssue[],
+  name: string,
+  target: string,
+): void {
+  issues.push({
+    name,
+    target,
+    reason:
+      'typescript target uses node shebang and is not directly runnable',
+    hint:
+      'use #!/usr/bin/env tsx or remove shebang to use launcher inference',
+  });
+}
+
 export function prepareBinTargets(
   cwd: string,
   bin: Record<string, string>,
@@ -117,7 +141,14 @@ export function prepareBinTargets(
       continue;
     }
 
-    if (hasShebang(target)) {
+    const shebang = readShebang(target);
+    if (shebang) {
+      const shebangRuntime = extractShebangRuntime(shebang);
+      if (isTypeScriptTarget(target) && shebangRuntime === 'node') {
+        addInvalidTypeScriptNodeShebangIssue(issues, name, target);
+        continue;
+      }
+
       const executableIssue = ensureExecutable(target, stats.mode);
       if (executableIssue) {
         issues.push({

--- a/src/lib/shebang.ts
+++ b/src/lib/shebang.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 export function readShebang(filePath: string): string | undefined {
   const raw = fs.readFileSync(filePath, 'utf8');
@@ -9,6 +10,44 @@ export function readShebang(filePath: string): string | undefined {
   }
 
   return firstLine;
+}
+
+function tokenizeShebangCommand(shebang: string): string[] {
+  return shebang
+    .slice(2)
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/^['"]|['"]$/g, ''))
+    .filter(Boolean);
+}
+
+export function extractShebangRuntime(shebang: string): string | undefined {
+  const tokens = tokenizeShebangCommand(shebang);
+  if (tokens.length === 0) {
+    return undefined;
+  }
+
+  const command = tokens[0];
+  const commandBase = path.basename(command).toLowerCase();
+
+  if (commandBase === 'env') {
+    // env-style shebangs can include flags before the actual runtime command.
+    const runtimeToken = tokens.slice(1).find((token) => !token.startsWith('-'));
+    if (!runtimeToken) {
+      return undefined;
+    }
+    return path.basename(runtimeToken).toLowerCase();
+  }
+
+  return commandBase;
+}
+
+export function readShebangRuntime(filePath: string): string | undefined {
+  const shebang = readShebang(filePath);
+  if (!shebang) {
+    return undefined;
+  }
+  return extractShebangRuntime(shebang);
 }
 
 export function hasShebang(filePath: string): boolean {

--- a/test/bin-targets.test.ts
+++ b/test/bin-targets.test.ts
@@ -134,6 +134,26 @@ test('infers tsx launcher for TypeScript targets without a shebang', () => {
   });
 });
 
+test('rejects TypeScript targets with node shebang and guides recovery', () => {
+  withTempDir((dirPath) => {
+    const targetPath = path.join(dirPath, 'src', 'cli.ts');
+    writeTarget(targetPath, {
+      content: '#!/usr/bin/env node\nconsole.log("ok")\n',
+      mode: 0o755,
+    });
+
+    assert.throws(
+      () => prepareBinTargets(dirPath, { 'my-cli': targetPath }),
+      /typescript target uses node shebang and is not directly runnable/,
+    );
+
+    assert.throws(
+      () => prepareBinTargets(dirPath, { 'my-cli': targetPath }),
+      /use #!\/usr\/bin\/env tsx or remove shebang to use launcher inference/,
+    );
+  });
+});
+
 test('rejects unsupported targets without shebang with manual-shebang guidance', () => {
   withTempDir((dirPath) => {
     const targetPath = path.join(dirPath, 'scripts', 'cli.py');

--- a/test/link-command.test.ts
+++ b/test/link-command.test.ts
@@ -279,6 +279,44 @@ test(
 );
 
 test(
+  'link fails early for TypeScript targets using node shebang',
+  { skip: isWindows },
+  () => {
+    withTempDir((dirPath) => {
+      const homeDirectory = path.join(dirPath, 'home');
+      const projectDirectory = path.join(dirPath, 'project');
+      const targetPath = path.join(projectDirectory, 'src', 'cli.ts');
+      fs.mkdirSync(homeDirectory, { recursive: true });
+      fs.mkdirSync(projectDirectory, { recursive: true });
+
+      writeJSON(path.join(projectDirectory, 'package.json'), {
+        name: 'sample-cli-project',
+        bin: {
+          'sample-cli': './src/cli.ts',
+        },
+      });
+
+      writeTarget(targetPath, {
+        content: '#!/usr/bin/env node\nconsole.log("ok")\n',
+        mode: 0o755,
+      });
+
+      const result = runCli(['link'], projectDirectory, { homeDirectory });
+
+      assert.equal(result.status, 1);
+      assert.match(
+        String(result.stderr),
+        /typescript target uses node shebang and is not directly runnable/,
+      );
+      assert.match(
+        String(result.stderr),
+        /use #!\/usr\/bin\/env tsx or remove shebang to use launcher inference/,
+      );
+    });
+  },
+);
+
+test(
   'link fails with manual-shebang guidance when a shebang-less target type is not supported yet',
   { skip: isWindows },
   () => {

--- a/usage/link.md
+++ b/usage/link.md
@@ -143,6 +143,14 @@ If target has no shebang and symlx cannot support that launcher path yet:
 - error tells you this is not supported yet without shebang
 - error tells you to explicitly specify shebang in target file
 
+### TypeScript Target Uses Node Shebang
+
+If a `.ts`/`.tsx`/`.mts`/`.cts` target file declares a `node` shebang:
+
+- process exits `1`
+- error tells you this target is not directly runnable
+- error tells you to use `#!/usr/bin/env tsx` or remove shebang for launcher inference
+
 ### Invalid Bin Target
 
 If a resolved bin target is missing, cannot be made executable, is a directory, or is unsupported in the no-shebang path:

--- a/usage/serve.md
+++ b/usage/serve.md
@@ -383,7 +383,15 @@ Outcome:
 - early runtime validation error telling you this path is not supported yet without shebang
 - message still guides manual shebang declaration
 
-## 27) Invalid config for non-critical keys
+## 27) TypeScript target with node shebang
+
+Outcome:
+
+- early runtime validation error
+- message says this target is not directly runnable
+- recovery tells you to use `#!/usr/bin/env tsx` or remove shebang for launcher inference
+
+## 28) Invalid config for non-critical keys
 
 `symlx.config.json`:
 
@@ -399,7 +407,7 @@ Outcome:
 - warning logs
 - defaults applied
 
-## 28) Invalid config for critical key (`binDir`)
+## 29) Invalid config for critical key (`binDir`)
 
 Outcome:
 
@@ -407,7 +415,7 @@ Outcome:
 
 ## Lifecycle Scenarios
 
-## 29) Controlled exit
+## 30) Controlled exit
 
 Stop with `Ctrl+C`.
 
@@ -416,7 +424,7 @@ Outcome:
 - active session links removed
 - session metadata file removed
 
-## 30) Stale crash recovery
+## 31) Stale crash recovery
 
 Previous run crashed and left stale session metadata.
 
@@ -434,6 +442,11 @@ Outcome:
 ## "not supported yet without shebang"
 
 - add shebang to target file to declare runner explicitly
+
+## "typescript target uses node shebang and is not directly runnable"
+
+- update target shebang to `#!/usr/bin/env tsx`
+- or remove shebang and let symlx infer launcher by file type
 
 ## "no bin entries found"
 


### PR DESCRIPTION
fix issue with unknown file extension when using a node shebang for a typescript target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added early detection and validation for TypeScript targets using node shebangs, which are not directly runnable. The tool now guides users to either switch to a tsx shebang or remove the shebang for launcher inference.

* **Documentation**
  * Updated guides with new troubleshooting sections explaining TypeScript node-shebang handling and recovery steps.

* **Tests**
  * Added test coverage for TypeScript targets with node-shebang scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->